### PR TITLE
fix - gluon-mesh-babel: do not require clat or plat prefix for valid …

### DIFF
--- a/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
+++ b/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
@@ -17,10 +17,10 @@ file:write("redistribute ip " .. site.next_node.ip6() .. "/128 deny\n")
 file:write("redistribute ip " .. site.prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip " .. site.node_client_prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip " .. site.node_prefix6() .. " eq 128  allow\n")
-if (site.plat_range()
+if site.plat_range() ~= nil and site.plat_range() ~= '' then
 	file:write("redistribute ip " .. site.plat_range() .. " eq 96  allow\n")
 end
-if site.clat_range() then
+if site.clat_range() ~= nil and site.clat_range() ~= '' then
 	file:write("redistribute ip " .. site.clat_range() .. " eq 96  allow\n")
 end
 file:write("redistribute local if br-wan deny\n")


### PR DESCRIPTION
…configuration