### PR TITLE
fix mac_to_ip by calling renamed function generate_ip_from_prefix

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/iputil.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/iputil.lua
@@ -96,6 +96,6 @@ function generate_ip_from_prefix(prefix, mac, firstbyte, secondbyte)
 end
 
 function mac_to_ip(prefix, mac)
-	return generate_ip(prefix, mac, 0xff, 0xfe)
+	return generate_ip_from_prefix(prefix, mac, 0xff, 0xfe)
 end
 


### PR DESCRIPTION
it crashed on: /lib/gluon/upgrade/300-gluon-mesh-babel-ip6